### PR TITLE
Add ceph configuration defaults

### DIFF
--- a/src/ceph.py
+++ b/src/ceph.py
@@ -202,7 +202,11 @@ def update_pool(client, pool, settings):
     """
     cmd = ["ceph", "--id", client, "osd", "pool", "set", pool]
     for k, v in settings.items():
-        check_call(cmd + [k, v])
+        # Add --yes-i-really-mean-it flag if setting pool size 1
+        extend_cmd = [k, v]
+        if k == "size" and v == "1":
+            extend_cmd = extend_cmd + ["--yes-i-really-mean-it"]
+        check_call(cmd + extend_cmd)
 
 
 def set_app_name_for_pool(client, pool, name):


### PR DESCRIPTION
Add mon_allow_pool_size_one and osd_pool_default_size to ceph configuration so that ceph supports single node deployment.
Use --yes-i-really-mean-it flag while setting the pool size to 1.