### PR TITLE
Update pool size as part of pool update

### DIFF
--- a/src/ceph.py
+++ b/src/ceph.py
@@ -795,3 +795,10 @@ class ReplicatedPool(BasePool):
         update_pool(client=self.service, pool=self.name, settings={"size": str(self.replicas)})
         # Perform other common post pool creation tasks
         super(ReplicatedPool, self)._post_create()
+
+    def update(self):
+        """Update properties for an already existing pool."""
+        # Set the pool replica size
+        update_pool(client=self.service, pool=self.name, settings={"size": str(self.replicas)})
+        # Perform other common post pool creation tasks
+        super(ReplicatedPool, self).update()


### PR DESCRIPTION
For replicated pool, update the pool size if the
replica changes as part of broker request on
existing pool.